### PR TITLE
Adding dfu-util programming util

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,6 +127,10 @@ jobs:
      env:
      - PACKAGE=fxload
 
+   - stage: "Other Tools"
+     env:
+     - PACKAGE=dfu-util
+
    # Verilog tools
    - stage: "Verilog Tools"
      env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ jobs:
      - PACKAGE=gcc/newlib   TOOLCHAIN_ARCH=or1k
    - stage: "GCC - Linux (musl)"
      env:
-     - PACKAGE=gcc/linux-musl TOOLCHAIN_ARCH=or1k     
+     - PACKAGE=gcc/linux-musl TOOLCHAIN_ARCH=or1k
    - stage: "GDB"
      env:
      - PACKAGE=gdb          TOOLCHAIN_ARCH=or1k
@@ -70,7 +70,7 @@ jobs:
      - PACKAGE=gcc/newlib   TOOLCHAIN_ARCH=riscv32
    - stage: "GCC - Linux (musl)"
      env:
-     - PACKAGE=gcc/linux-musl TOOLCHAIN_ARCH=riscv32     
+     - PACKAGE=gcc/linux-musl TOOLCHAIN_ARCH=riscv32
    - stage: "GDB"
      env:
      - PACKAGE=gdb          TOOLCHAIN_ARCH=riscv32

--- a/dfu-util/build.sh
+++ b/dfu-util/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [ x"$TRAVIS" = xtrue ]; then
+	CPU_COUNT=2
+fi
+
+./autogen.sh
+./configure --prefix=$PREFIX
+make -j$CPU_COUNT
+make install
+
+dfu-util --help || true

--- a/dfu-util/meta.yaml
+++ b/dfu-util/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG or 'v0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
+package:
+  name: dfu-util
+  version: {{ version }}
+
+source:
+  git_url: https://git.code.sf.net/p/dfu-util/dfu-util.git
+  git_rev: master
+
+build:
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - pkg-config
+  host:
+    - libusb
+  run:
+    - libusb
+
+about:
+  home: http://dfu-util.sourceforge.net
+  license_file: COPYING
+  summary: 'Device Firmware Upgrade Utilities'
+
+extra:
+  maintainers:
+    - Tim 'mithro' Ansell <mithro@mithis.com>
+    - HDMI2USB Project - https://hdmi2usb.tv <hdmi2usb@googlegroups.com>

--- a/dfu-util/run_test.sh
+++ b/dfu-util/run_test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+set +x
+
+dfu-util --help || true
+dfu-util --version


### PR DESCRIPTION
`dfu-util` is needed for programming FPGA Tomu boards.